### PR TITLE
Scan installed R-packages for vulnerabilities

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -40,7 +40,9 @@ RUN apt update && \
 RUN R CMD javareconf -e && \
     R -e "install.packages('RTextTools', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('configr', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
-    R -e "install.packages('RegSDC', dependencies=FALSE, repos='http://cran.rstudio.com/')"
+    R -e "install.packages('RegSDC', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('oysteR', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
+    R -e "require(devtools); install_version('widgetframe', version = '0.3.0')"  # Just for test detecting vulnerabilities
 
 RUN R -e "remotes::install_github('r-barnes/dggridR', vignette=TRUE)" && \
     R -e "remotes::install_github('statisticsnorway/Kostra')" && \
@@ -205,3 +207,8 @@ RUN mkdir "$WORKON_HOME" && \
     chown -R $NB_UID "$WORKON_HOME"
 
 USER $NB_UID
+
+# Copy and run R-script for scanning installed R-packages
+# docker build fails if vulnerabilities are found
+COPY scan.R /tmp/
+RUN Rscript /tmp/scan.R

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -41,8 +41,7 @@ RUN R CMD javareconf -e && \
     R -e "install.packages('RTextTools', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('configr', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('RegSDC', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
-    R -e "install.packages('oysteR', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
-    R -e "require(devtools); install_version('widgetframe', version = '0.3.0')"  # Just for test detecting vulnerabilities
+    R -e "install.packages('oysteR', dependencies=TRUE, repos='http://cran.rstudio.com/')"
 
 RUN R -e "remotes::install_github('r-barnes/dggridR', vignette=TRUE)" && \
     R -e "remotes::install_github('statisticsnorway/Kostra')" && \

--- a/docker/jupyterlab/scan.R
+++ b/docker/jupyterlab/scan.R
@@ -1,0 +1,12 @@
+# This script scans the installed R-packges for security issues.
+# It requires that the oyestR-package is installed:
+# https://github.com/sonatype-nexus-community/oysteR
+
+library("oysteR")
+audit = audit_installed_r_pkgs()
+vulns = get_vulnerabilities(audit)
+print(vulns)
+
+if (nrow(vulns) > 0) {
+    quit(save = "no", status = 1, runLast = FALSE)
+}


### PR DESCRIPTION
This should trigger a warning about R-package widget 0.3.0 being a vulnerable package, according to this Jira issue: https://statistics-norway.atlassian.net/jira/software/projects/DAPLA/boards/10?selectedIssue=DAPLA-486

This should not be merged, and is only a test to see if vulnerabilities in R-packages are picked up on by our build pipeline.