### PR TITLE
DAPLA-486: Add scanning of spark-r image

### DIFF
--- a/docker/spark-r/Dockerfile
+++ b/docker/spark-r/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/apache/spark/blob/master/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
 
 # Use base image that has the same JRE as jupyter/all-spark-notebook
-FROM adoptopenjdk/openjdk11:jre-11.0.9.1_1-ubuntu
+FROM eclipse-temurin:11.0.13_8-jre-focal AS prod
 WORKDIR /
 
 # Reset to root to run installation tasks
@@ -42,7 +42,7 @@ ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
 RUN \
   echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" >> /etc/apt/sources.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
   apt-get update && \
   apt install -y -t focal-cran40 r-base r-base-dev r-base-core r-recommended && \
   rm -rf /var/cache/apt/*
@@ -61,3 +61,19 @@ ENTRYPOINT [ "/opt/entrypoint.sh" ]
 ARG spark_uid=185
 USER ${spark_uid}
 
+
+# Add a second stage for scanning the prod container.
+FROM prod AS scan
+USER root
+
+RUN apt-get update && \
+    apt-get install -y libssl-dev libcurl4-openssl-dev libxml2-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add R-library for scanning for vulnerabilities
+RUN R -e "install.packages('oysteR', dependencies=TRUE)"
+
+# Copy and run R-script for scanning installed R-packages
+# docker build fails if vulnerabilities are found
+COPY scan.R /tmp/
+RUN Rscript /tmp/scan.R

--- a/docker/spark-r/azure-pipelines.yml
+++ b/docker/spark-r/azure-pipelines.yml
@@ -16,7 +16,7 @@ resources:
     - repository: templates
       type: github
       name: statisticsnorway/azure-pipelines-templates
-      ref: refs/tags/0.1.3
+      ref: refs/tags/1.1.28
       endpoint: statisticsnorway (6)
 
     # Pipeline will be run on this base image
@@ -51,12 +51,19 @@ jobs:
     condition: eq(False, startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
     displayName: 'Build Docker image for dapla spark R operator'
     steps:
+      - task: Docker@2
+        displayName: Build and scan
+        inputs:
+          command: build
+          Dockerfile: 'docker/spark-r/Dockerfile'
+          repository: $(repoName)-scan
+
       - template: docker/docker-build-image-and-push-to-gcr.yml@templates
         parameters:
-          project: dapla
           imageName: $(imageName)
           repoName: $(repoName)
           Dockerfile: 'docker/spark-r/Dockerfile'
+          buildArguments: '--target prod'
 
       # Need to tag 'latest' image (used by docker-tag-for-production)
       - script: |

--- a/docker/spark-r/scan.R
+++ b/docker/spark-r/scan.R
@@ -1,0 +1,12 @@
+# This script scans the installed R-packges for security issues.
+# It requires that the oyestR-package is installed:
+# https://github.com/sonatype-nexus-community/oysteR
+
+library("oysteR")
+audit = audit_installed_r_pkgs()
+vulns = get_vulnerabilities(audit)
+print(vulns)
+
+if (nrow(vulns) > 0) {
+    quit(save = "no", status = 1, runLast = FALSE)
+}


### PR DESCRIPTION
- Update base image to match current jre in jupyter/all-spark-notebook
- Change from AdoptOpenJDK to eclipse-temurin, the new name:
  https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
- Add a scan stage as the last stage in a multistage docker build