### PR TITLE
pyspark executor safety check and trivy scan

### DIFF
--- a/docker/spark-py/Dockerfile
+++ b/docker/spark-py/Dockerfile
@@ -20,13 +20,11 @@ RUN set -ex && \
     apt-get -y dist-upgrade && \
     apt install -y python3 python3-pip && \
     pip3 install --upgrade pip setuptools && \
-    # You may install python3 packages by using pip3
-    # Remove the .cache to save space
     apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
     libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev curl && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
-    rm -r /root/.cache && rm -rf /var/cache/apt/*
+    rm -r /root/.cache && rm -rf /var/cache/apt/*     # Remove the .cache to save space
 
 # Add Tini (not found via apt-get)
 ENV TINI_VERSION v0.19.0

--- a/docker/spark-py/Dockerfile
+++ b/docker/spark-py/Dockerfile
@@ -20,8 +20,8 @@ RUN set -ex && \
     apt-get -y dist-upgrade && \
     apt install -y python3 python3-pip && \
     pip3 install --upgrade pip setuptools && \
-    # You may install with python3 packages by using pip3.6
-    # Removed the .cache to save space
+    # You may install python3 packages by using pip3
+    # Remove the .cache to save space
     apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
     libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev curl && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
@@ -60,6 +60,17 @@ WORKDIR /opt/spark/work-dir
 RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
+
+# Python vuln check, and remove package afterwards
+RUN pip install safety && \
+    safety check && \
+    pip uninstall -y safety && \
+    pip cache purge
+
+# Filesystem vuln check of image/os, and remove package after
+COPY --from=aquasec/trivy:latest /usr/local/bin/trivy /usr/local/bin/trivy
+RUN trivy filesystem --ignore-unfixed --exit-code 0 --severity HIGH,CRITICAL / && \
+    rm -rf /usr/local/bin/trivy
 
 # Specify the User that the actual main process will run as
 ARG spark_uid=185


### PR DESCRIPTION
Python safety check fails build if it doesn't pass.

The trivy scan is configured to not fail the build, but is included anyways to display any vulnerabilities in the OS and JDK.