### PR TITLE
allow user write to r lib folder

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV R_HOME /usr/lib/R
+ENV R_LIBS_USER /usr/lib/R/library
 
 COPY r-packages.txt /tmp/r-packages.txt
 
@@ -204,6 +205,9 @@ RUN chmod +x /opt/dapla/pipenv_kernel.sh && \
 ENV WORKON_HOME="/virtualenvs"
 RUN mkdir "$WORKON_HOME" && \
     chown -R $NB_UID "$WORKON_HOME"
+
+# Allow notebook user to write (install) new R packages to the library
+RUN chown -R $NB_UID "$R_LIBS_USER"
 
 # Image vulnerability scan. If exit code set to 1, fails image build
 COPY --from=aquasec/trivy:latest /usr/local/bin/trivy /usr/local/bin/trivy

--- a/docker/jupyterlab/sparkR_k8s/kernel.json
+++ b/docker/jupyterlab/sparkR_k8s/kernel.json
@@ -12,6 +12,7 @@
   "env": {
     "SPARK_HOME": "/usr/local/spark",
     "SPARKR_SUBMIT_ARGS": "${SPARKR_K8S_SUBMIT_ARGS}",
-    "R_PROFILE_USER" : "/opt/conda/share/jupyter/kernels/ir_k8s/Rstartup"
+    "R_PROFILE_USER" : "/opt/conda/share/jupyter/kernels/ir_k8s/Rstartup",
+    "R_LIBS_USER": "/usr/lib/R/library"
   }
 }

--- a/docker/jupyterlab/sparkR_local/kernel.json
+++ b/docker/jupyterlab/sparkR_local/kernel.json
@@ -12,6 +12,7 @@
   "env": {
     "SPARK_HOME": "/usr/local/spark",
     "SPARKR_SUBMIT_ARGS": "${SPARKR_LOCAL_SUBMIT_ARGS}",
-    "R_PROFILE_USER" : "/opt/conda/share/jupyter/kernels/ir/Rstartup"
+    "R_PROFILE_USER" : "/opt/conda/share/jupyter/kernels/ir/Rstartup",
+    "R_LIBS_USER": "/usr/lib/R/library"
   }
 }


### PR DESCRIPTION
In order to install new packages from CRAN, the user needs write access to the library folder. This PR gives the user access to write to `/usr/lib/R/library`

Setting the "R_LIBS_USER" env variable to `/usr/lib/R/library` makes that path the default lib for installing packages. I set it both in the dockerfile, and in the `kernel.json` env vars.

All the alternate lib paths retrieved at runtime from the notebook with ".libPaths()" are:
```
/usr/local/spark-3.2.0-bin-hadoop3.2/R/lib
/usr/local/lib/R/site-library
/usr/lib/R/site-library
/usr/lib/R/library
```
But I dont know if we need write access to all those paths?