### PR TITLE
inject pip indec url

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -207,7 +207,10 @@ RUN /opt/dapla/dapla-cli completion bash > /etc/bash_completion.d/dapla && \
 # - Add aliases
 COPY pipenv_kernel.bash /opt/dapla/pipenv_kernel.sh
 RUN chmod +x /opt/dapla/pipenv_kernel.sh && \
-    echo "alias pipenv-kernel='/opt/dapla/pipenv_kernel.sh'" >> /etc/bash.bashrc
+    echo "alias pipenv-kernel='/opt/dapla/pipenv_kernel.sh'" >> /etc/bash.bashrc && \
+    echo 'export PIP_INDEX="https://jupyter:$PYPISERVER_PASSWORD@dapla-pypiserver.$CLUSTER_ID.ssb.no"' >> /etc/bash.bashrc && \
+    echo 'export PIP_INDEX_URL="$PIP_INDEX"' >> /etc/bash.bashrc && \
+    echo 'export PIPENV_PYPI_MIRROR="$PIP_INDEX"' >> /etc/bash.bashrc
 
 # Virtual environments should be stored in the container, so that they don't fill the 2G storage of the home dir.
 ENV WORKON_HOME="/virtualenvs"

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -208,7 +208,7 @@ RUN /opt/dapla/dapla-cli completion bash > /etc/bash_completion.d/dapla && \
 COPY pipenv_kernel.bash /opt/dapla/pipenv_kernel.sh
 RUN chmod +x /opt/dapla/pipenv_kernel.sh && \
     echo "alias pipenv-kernel='/opt/dapla/pipenv_kernel.sh'" >> /etc/bash.bashrc && \
-    echo 'export PIP_INDEX="https://jupyter:$PYPISERVER_PASSWORD@dapla-pypiserver.$CLUSTER_ID.ssb.no"' >> /etc/bash.bashrc && \
+    echo 'export PIP_INDEX="https://jupyter:$PYPISERVER_PASSWORD@dapla-pypiserver-39.$CLUSTER_ID.ssb.no"' >> /etc/bash.bashrc && \
     echo 'export PIP_INDEX_URL="$PIP_INDEX"' >> /etc/bash.bashrc && \
     echo 'export PIPENV_PYPI_MIRROR="$PIP_INDEX"' >> /etc/bash.bashrc
 


### PR DESCRIPTION
We are not allowing egress to pypi.org any more, so we have to point to the dapla-pypiserver with the environment variables, like we do for the old jupyter.