### PR TITLE
upgrade spark and python versions in executors

### DIFF
--- a/docker/spark-py/Dockerfile
+++ b/docker/spark-py/Dockerfile
@@ -41,15 +41,15 @@ ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 
 # Python 3.x is not available in the standard Debian 10 repositories, so
 # it must be built from source
-RUN wget -O Python-3.9.10.tar.xz https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tar.xz && \
-    tar -xf Python-3.9.10.tar.xz && \
-    rm Python-3.9.10.tar.xz
+RUN wget -O Python-3.9.7.tar.xz https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tar.xz && \
+    tar -xf Python-3.9.7.tar.xz && \
+    rm Python-3.9.7.tar.xz
 
-RUN cd Python-3.9.10 && \
+RUN cd Python-3.9.7 && \
     ./configure --enable-optimizations && \
     make -j 4 && \
     make install && \
-    rm -rf Python-3.9.10
+    rm -rf Python-3.9.7
 
 COPY entrypoint.sh /opt/
 COPY decom.sh /opt/

--- a/docker/spark-py/Dockerfile
+++ b/docker/spark-py/Dockerfile
@@ -32,24 +32,24 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/
 RUN chmod +x /usr/bin/tini
 
 # Install latest Spark version
-RUN wget https://apache.uib.no/spark/spark-3.2.0/spark-3.2.0-bin-hadoop3.2.tgz && \
-    tar -zxpf spark-3.2.0-bin-hadoop3.2.tgz -C /tmp && \
-    mv /tmp/spark-3.2.0-bin-hadoop3.2 ${SPARK_HOME} && \
-    rm -rf /tmp/spark-3.2.0-bin-hadoop3.2 && \
-    rm spark-3.2.0-bin-hadoop3.2.tgz
+RUN wget https://apache.uib.no/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz && \
+    tar -zxpf spark-3.2.1-bin-hadoop3.2.tgz -C /tmp && \
+    mv /tmp/spark-3.2.1-bin-hadoop3.2 ${SPARK_HOME} && \
+    rm -rf /tmp/spark-3.2.1-bin-hadoop3.2 && \
+    rm spark-3.2.1-bin-hadoop3.2.tgz
 ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 
 # Python 3.x is not available in the standard Debian 10 repositories, so
 # it must be built from source
-RUN wget -O Python-3.9.7.tar.xz https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tar.xz && \
-    tar -xf Python-3.9.7.tar.xz && \
-    rm Python-3.9.7.tar.xz
+RUN wget -O Python-3.9.10.tar.xz https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tar.xz && \
+    tar -xf Python-3.9.10.tar.xz && \
+    rm Python-3.9.10.tar.xz
 
-RUN cd Python-3.9.7 && \
+RUN cd Python-3.9.10 && \
     ./configure --enable-optimizations && \
     make -j 4 && \
     make install && \
-    rm -rf Python-3.9.7
+    rm -rf Python-3.9.10
 
 COPY entrypoint.sh /opt/
 COPY decom.sh /opt/

--- a/docker/spark-r/Dockerfile
+++ b/docker/spark-r/Dockerfile
@@ -30,11 +30,11 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/
 RUN chmod +x /usr/bin/tini
 
 # Install latest Spark version
-RUN wget https://apache.uib.no/spark/spark-3.2.0/spark-3.2.0-bin-hadoop3.2.tgz && \
-    tar -zxpf spark-3.2.0-bin-hadoop3.2.tgz -C /tmp && \
-    mv /tmp/spark-3.2.0-bin-hadoop3.2 ${SPARK_HOME} && \
-    rm -rf /tmp/spark-3.2.0-bin-hadoop3.2 && \
-    rm spark-3.2.0-bin-hadoop3.2.tgz
+RUN wget https://apache.uib.no/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz && \
+    tar -zxpf spark-3.2.1-bin-hadoop3.2.tgz -C /tmp && \
+    mv /tmp/spark-3.2.1-bin-hadoop3.2 ${SPARK_HOME} && \
+    rm -rf /tmp/spark-3.2.1-bin-hadoop3.2 && \
+    rm spark-3.2.1-bin-hadoop3.2.tgz
 ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 
 # Install R 4.0.1 (http://cloud.r-project.org/bin/linux/debian/)


### PR DESCRIPTION
The latest jupyterlab pyspark notebook still uses 3.2.0, but maybe we can use 3.2.1 on the executors to get the bugfixes for our code running in k8s.

I also upgrade to the latest python 3.9 patch.

Since the notebook runs python 3.9 and spark 3.2 with older patches, the code should be 100% compatible, but bugs that might be a problem running locally might not be a problem when running on the executors.