### PR TITLE
Upgrade base image for jupyterlab

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -1,6 +1,6 @@
 # Image contains Spark 3.2.0
 # jupyter/pyspark-notebook includes Python support for Apache Spark and pyarrow library
-FROM jupyter/pyspark-notebook:spark-3.2.0 AS ssb-r-packages
+FROM jupyter/pyspark-notebook:spark-3.2.1 AS ssb-r-packages
 
 USER root
 

--- a/docker/jupyterlab/pyspark_k8s/kernel.json
+++ b/docker/jupyterlab/pyspark_k8s/kernel.json
@@ -10,7 +10,7 @@
   ],
   "env": {
     "SPARK_HOME": "/usr/local/spark",
-    "PYTHONPATH": "/usr/local/spark/python:/usr/local/spark/python/lib/py4j-0.10.9.2-src.zip",
+    "PYTHONPATH": "/usr/local/spark/python:/usr/local/spark/python/lib/py4j-0.10.9.3-src.zip",
     "PYTHON_EXEC": "python",
     "PYSPARK_DRIVER_PYTHON": "jupyter",
     "PYSPARK_PYTHON": "python3",

--- a/docker/jupyterlab/pyspark_local/kernel.json
+++ b/docker/jupyterlab/pyspark_local/kernel.json
@@ -10,7 +10,7 @@
   ],
   "env": {
     "SPARK_HOME": "/usr/local/spark",
-    "PYTHONPATH": "/usr/local/spark/python:/usr/local/spark/python/lib/py4j-0.10.9.2-src.zip",
+    "PYTHONPATH": "/usr/local/spark/python:/usr/local/spark/python/lib/py4j-0.10.9.3-src.zip",
     "PYTHON_EXEC": "python",
     "PYSPARK_DRIVER_PYTHON": "jupyter",
     "PYSPARK_PYTHON": "python3",


### PR DESCRIPTION
Inspecting the base image, and I noticed that the py4j version has been bumped, but Python version remains the same (3.9.7)

<img width="873" alt="Skjermbilde 2022-02-08 kl  09 18 23" src="https://user-images.githubusercontent.com/31540110/152946140-d7caf783-ccb2-42de-8d39-d77bc761d239.png">
