### PR TITLE
Added R packages (and deps) for textreadr and leaflet

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -51,6 +51,9 @@ RUN R CMD javareconf -e && \
     R -e "install.packages('cppRouting', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('rjwsacruncher', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('klassR', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('antiword', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('textshape', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('striprtf', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('textreadr', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('terra', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('raster', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -51,6 +51,10 @@ RUN R CMD javareconf -e && \
     R -e "install.packages('cppRouting', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('rjwsacruncher', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     R -e "install.packages('klassR', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('textreadr', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('terra', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('raster', dependencies=FALSE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages('leaflet', dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     # Doesn t work with Java11 - use a custom one
     #curl --silent -L -o- https://github.com/jdemetra/jwsacruncher/releases/download/v2.2.3/jwsacruncher-2.2.3-bin.zip | bsdtar -xvf- -C /opt && \
     unzip /tmp/jwsacruncher-2.2.4.zip -d /opt && fix-permissions /opt/jwsacruncher-2.2.4 && rm -f /tmp/jwsacruncher-2.2.4.zip

--- a/docker/jupyterlab/r-packages.txt
+++ b/docker/jupyterlab/r-packages.txt
@@ -34,3 +34,5 @@ r-cran-ipred
 r-cran-catools
 r-cran-tau
 r-cran-here
+r-cran-pdftools
+r-cran-tesseract

--- a/docker/jupyterlab/r-packages.txt
+++ b/docker/jupyterlab/r-packages.txt
@@ -36,3 +36,4 @@ r-cran-tau
 r-cran-here
 r-cran-pdftools
 r-cran-tesseract
+r-cran-sp


### PR DESCRIPTION
The package r-cran-textreadr did not exist, so we need to install from R.

Also tried the command `apt-get install r-cran-leaflet r-cran-raster r-cran-terra` but that failed with the error:

```
The following packages have unmet dependencies:
 r-cran-terra : Depends: libgdal29 (>= 3.0.3) but it is not installable
                Depends: libproj19 (>= 7.1.0) but it is not installable
```

So in the end most of the packages and dependencies are installed from R.