### PR TITLE
dapla-pypiserver as index for py39

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -223,7 +223,7 @@ RUN /opt/dapla/dapla-cli completion bash > /etc/bash_completion.d/dapla && \
 COPY pipenv_kernel.bash /opt/dapla/pipenv_kernel.sh
 RUN chmod +x /opt/dapla/pipenv_kernel.sh && \
     echo "alias pipenv-kernel='/opt/dapla/pipenv_kernel.sh'" >> /etc/bash.bashrc && \
-    echo 'export PIP_INDEX="https://jupyter:$PYPISERVER_PASSWORD@dapla-pypiserver-39.$CLUSTER_ID.ssb.no"' >> /etc/bash.bashrc && \
+    echo 'export PIP_INDEX="https://jupyter:$PYPISERVER_PASSWORD@dapla-pypiserver.$CLUSTER_ID.ssb.no"' >> /etc/bash.bashrc && \
     echo 'export PIP_INDEX_URL="$PIP_INDEX"' >> /etc/bash.bashrc && \
     echo 'export PIPENV_PYPI_MIRROR="$PIP_INDEX"' >> /etc/bash.bashrc
 


### PR DESCRIPTION
As of merging [this pr](https://github.com/statisticsnorway/platform-dev/pull/2023), the regular "dapla-pypiserver" now serves py39 packages in staging. 

This jupyter image needs to point to the correct url for getting py39 packages, and that's what this change does.