### PR TITLE
Fix trusted host

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -227,7 +227,7 @@ RUN chmod +x /opt/dapla/pipenv_kernel.sh && \
     echo 'export PIP_INDEX="http://jupyter:$PYPISERVER_PASSWORD@dapla-pypiserver.dapla.svc.cluster.local"' >> /etc/bash.bashrc && \
     echo 'export PIP_INDEX_URL="$PIP_INDEX"' >> /etc/bash.bashrc && \
     echo 'export PIPENV_PYPI_MIRROR="$PIP_INDEX"' >> /etc/bash.bashrc && \
-    echo 'export PIP_TRUSTED_HOST="dapla-pypiserver.dapla.svc.cluster.local"'  
+    echo 'export PIP_TRUSTED_HOST="dapla-pypiserver.dapla.svc.cluster.local"' >> /etc/bash.bashrc
 
 # Virtual environments should be stored in the container, so that they don't fill the 2G storage of the home dir.
 ENV WORKON_HOME="/virtualenvs"

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -226,8 +226,7 @@ RUN chmod +x /opt/dapla/pipenv_kernel.sh && \
     echo "alias pipenv-kernel='/opt/dapla/pipenv_kernel.sh'" >> /etc/bash.bashrc && \
     echo 'export PIP_INDEX="http://jupyter:$PYPISERVER_PASSWORD@dapla-pypiserver.dapla.svc.cluster.local"' >> /etc/bash.bashrc && \
     echo 'export PIP_INDEX_URL="$PIP_INDEX"' >> /etc/bash.bashrc && \
-    echo 'export PIPENV_PYPI_MIRROR="$PIP_INDEX"' >> /etc/bash.bashrc && \
-    echo 'export PIP_TRUSTED_HOST="dapla-pypiserver.dapla.svc.cluster.local"' >> /etc/bash.bashrc
+    echo 'export PIPENV_PYPI_MIRROR="$PIP_INDEX"' >> /etc/bash.bashrc
 
 # Virtual environments should be stored in the container, so that they don't fill the 2G storage of the home dir.
 ENV WORKON_HOME="/virtualenvs"


### PR DESCRIPTION
Since the PIP_TRUSTED_HOST variable is set in platform-dev in the jupyterhub helm yaml: it does not need to be set here.

Also, since the line was missing ">> /etc/bash.bashrc" at the end, it did not do anything.