### PR TITLE
Create a separate kernel SparkR

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -14,8 +14,8 @@ COPY pyspark_k8s /usr/local/share/jupyter/kernels/pyspark_k8s/
 COPY pyspark_local /usr/local/share/jupyter/kernels/pyspark_local/
 COPY sparkR_k8s/kernel.json /opt/conda/share/jupyter/kernels/ir_k8s/
 COPY sparkR_k8s/Rstartup /opt/conda/share/jupyter/kernels/ir_k8s/
-COPY sparkR_local/kernel.json /opt/conda/share/jupyter/kernels/ir/
-COPY sparkR_local/Rstartup /opt/conda/share/jupyter/kernels/ir/
+COPY sparkR_local/kernel.json /opt/conda/share/jupyter/kernels/ir_spark/
+COPY sparkR_local/Rstartup /opt/conda/share/jupyter/kernels/ir_spark/
 
 USER root
 # Spark installation


### PR DESCRIPTION
This PR will create a separate kernel for SparkR. Previously the standard R-kernel was overridden. The result will be three kernels for R: standard, SparkR (local) and SparkR (k8s).

Local ticket no: STAT-105.