### PR TITLE
Set ssb-project template version to 1.0.1

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -83,7 +83,8 @@ RUN echo "**** install sphinx ****" && \
     python3 -m pip cache purge && \
     rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
-
+# Set template version for ssb-project-cli (https://github.com/statisticsnorway/ssb-project-template-stat)
+ENV STAT_TEMPLATE_DEFAULT_REFERENCE="1.0.1"
 ENV DAPLA_TEAM_API_BASE_URL="http://dapla-team-api.dapla.svc.cluster.local"
 
 


### PR DESCRIPTION
`ssb-project-cli` relies on the environment variable `STAT_TEMPLATE_DEFAULT_REFERENCE` to determine the default template version for new projects. This change sets `STAT_TEMPLATE_DEFAULT_REFERENCE` to point to the newly released version 1.0.1 of the 'ssb-project-template-stat' template.

Template release:
https://github.com/statisticsnorway/ssb-project-template-stat/releases/tag/1.0.1