### PR TITLE
Add gitconfig and DaplaLab init script

### DIFF
--- a/docker/jupyterlab/DapaLab/base_gitconfig
+++ b/docker/jupyterlab/DapaLab/base_gitconfig
@@ -1,0 +1,20 @@
+[color]
+	ui = auto
+[core]
+	autocrlf = input
+	editor = nano
+	eol = lf
+[credential]
+	helper = cache --timeout=86400
+[diff "ipynb"]
+	textconv = '/opt/conda/bin/python3' -m nbstripout -t
+[fetch]
+	prune = true
+[filter "nbstripout"]
+	clean = '/opt/conda/bin/python3' -m nbstripout
+	extrakeys = metadata.kernelspec metadata.language_info.version cell.metadata.pycharm metadata.language_info.pygments_lexer metadata.language_info.codemirror_mode.version
+	smudge = cat
+[init]
+	defaultBranch = main
+[push]
+	default = current

--- a/docker/jupyterlab/DapaLab/init.sh
+++ b/docker/jupyterlab/DapaLab/init.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+NETRC_FILE="$HOME/.netrc"
+INIT_PATH="$HOME"/work
+
+if [ -n "$GIT_USER_NAME" ] && [ -n "$GIT_PERSONAL_ACCESS_TOKEN" ]; then
+  if [ ! -f "$NETRC_FILE" ]; then
+    echo "machine github.com login $GIT_USER_NAME password $GIT_PERSONAL_ACCESS_TOKEN" >>"$NETRC_FILE"
+  fi
+fi
+
+# Configure git
+if [ -n "$GIT_USER_NAME" ]; then
+  git config --global user.name "$GIT_USER_NAME"
+fi
+
+if [ -n "$GIT_USER_MAIL" ]; then
+  git config --global user.email "$GIT_USER_MAIL"
+fi
+
+if [ -n "$GIT_REPOSITORY" ] && [ -f "$NETRC_FILE" ]; then
+  REPO_NAME="$(basename "$GIT_REPOSITORY" .git)"
+  REPO_PATH="$INIT_PATH/$REPO_NAME"
+  git clone "$GIT_REPOSITORY" "$REPO_PATH"
+
+  if [ -d "$REPO_PATH" ]; then
+    INIT_PATH="$REPO_PATH"
+    if [ -n "$GIT_BRANCH" ]; then
+      cd "$REPO_PATH"
+      git checkout "$GIT_BRANCH"
+      cd -
+    fi
+  fi
+fi
+
+echo "execution of $*"
+exec "$@" "$INIT_PATH"

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -105,4 +105,9 @@ RUN chown -R $NB_UID "$R_LIBS_USER"
 
 # User will not be able to install packages outside of a virtual environment
 ENV PIP_REQUIRE_VIRTUALENV=true
+
+# Add base gitconfig and DaplaLab init script
+COPY --chmod=0755 DapaLab/init.sh /opt/onyxia-init.sh
+COPY --chown=${NB_UID}:${NB_UID} DapaLab/base_gitconfig $HOME/.gitconfig
+
 USER $NB_UID


### PR DESCRIPTION
Add init script for DaplaLab. The script set up git config and credentials based on env variables provided by DaplaLab.
base_gitconfig is a direct copy of the recommended settings from Kvakk: [Kvakk's recommended gitconfig settings for Dapla](https://github.com/statisticsnorway/kvakk-git-tools/blob/main/kvakk_git_tools/recommended/gitconfig-dapla).

It also adds support for starting the service in a given repository.