### PR TITLE
Change working directory before starting jupyter

### DIFF
--- a/docker/jupyterlab/DapaLab/init.sh
+++ b/docker/jupyterlab/DapaLab/init.sh
@@ -31,6 +31,6 @@ if [ -n "$GIT_REPOSITORY" ] && [ -f "$NETRC_FILE" ]; then
     fi
   fi
 fi
-
 echo "execution of $*"
-exec "$@" "$INIT_PATH"
+cd "$INIT_PATH"
+exec "$@"


### PR DESCRIPTION
Previously, the command used to launch Jupyter from Dapla Beta was effectively:
```
jupyter lab --no-browser --ip '0.0.0.0' --LabApp.token='$(PASSWORD)' --ContentsManager.allow_hidden=True $INIT_PATH
```
Jupyter would start in init dir, but new terminals and notebooks were opening in the dir where the service was started.

After this PR the script first changes the directory to the desired init dir, and then launches Jupyter. This should resolve the issue.

**Other changes**:
The init dir reference has been removed from the end of the startup command, this is no longer needed, as the directory change is does the same thing*.