### PR TITLE
Give jovyan ownership of files and folders home dir

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -110,4 +110,7 @@ ENV PIP_REQUIRE_VIRTUALENV=true
 COPY --chmod=0755 DapaLab/init.sh /opt/onyxia-init.sh
 COPY --chown=${NB_UID}:${NB_UID} DapaLab/base_gitconfig $HOME/.gitconfig
 
+# Ensure that user owns everything in it's home directory
+RUN chown $NB_UID:users -R $HOME
+
 USER $NB_UID


### PR DESCRIPTION
Jovyan did not own these files in home dir:
```
/home/jovyan/.gnupg
find: ‘/home/jovyan/.gnupg’: Permission denied
/home/jovyan/.cache/R
/home/jovyan/.cache/R/R.cache
/home/jovyan/.cache/R/R.cache/README.txt
/home/jovyan/.launchpadlib
find: ‘/home/jovyan/.launchpadlib'
```
This resulted in errors when creating renvs as this writes to  `/home/jovyan/.cache/R `

This change ensures that Jovyan owns everything under $HOME, resolving the error.
