### PR TITLE
Remove datadoc

### DIFF
--- a/docker/jupyterlab/requirements.txt
+++ b/docker/jupyterlab/requirements.txt
@@ -1,6 +1,5 @@
 ssb-project-cli==1.4.0
 dapla-toolbelt==2.0.8
-ssb-datadoc==0.6.0
 dapla-team-cli==0.3.6
 kvakk-git-tools==2.2.2
 ssb_spark_tools==0.1.12


### PR DESCRIPTION
Remove datadoc due to JupyterLab no longer being a supported environment.