### PR TITLE
Bump TokenExchangeAuthenticator (0.3.4 -> 0.3.6)

### DIFF
--- a/docker/jupyterhub/Dockerfile
+++ b/docker/jupyterhub/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update && \
     apt-get -y dist-upgrade && \
     apt-get -y remove --auto-remove vim
 
-RUN pip install tokenexchangeauthenticator==0.3.4  && \
+RUN pip install tokenexchangeauthenticator==0.3.6  && \
     pip install jupyterhub-kubespawner==5.0.0
 
 # Set localtime to Europe/Oslo


### PR DESCRIPTION
Primary changes since `v0.3.4` can be found in this PR: https://github.com/statisticsnorway/jupyterhub-extensions/pull/8