### PR TITLE
Add tag main tag with timestamp

### DIFF
--- a/.github/workflows/docker-build-other-images.yml
+++ b/.github/workflows/docker-build-other-images.yml
@@ -92,6 +92,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{branch}}-{{sha}}-{{date 'YYYYMMDDHHmmss'}},enable={{is_default_branch}}
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}


### PR DESCRIPTION
Same change as https://github.com/statisticsnorway/jupyterhub-project/pull/172

This will allow us to setup image policies that uses the latest main image in `staging`.

An image policy like this has already been setup for the lab img, ref: https://github.com/statisticsnorway/flux2-tenant-jupyterhub/blob/f0adb5690744bbb7a434dbbb1b014e0544eacd8e/staging-bip-app/jupyterhub/imagepolicies.yaml#L58